### PR TITLE
Add sidebar layout for agentic UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 .env
-.windsurfrules
+

--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ pnpm install
 
 This will install all dependencies for both packages.
 
+### Environment Variables
+
+The backend requires an OpenAI API key. Copy the example file and add your key:
+
+```bash
+cp packages/backend/.env.example packages/backend/.env
+# edit packages/backend/.env and set OPENAI_KEY=your_openai_key
+```
+
+Restart the backend after updating the file.
+
+
 ### Development
 
 To start both frontend and backend in development mode:

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -1,0 +1,1 @@
+OPENAI_KEY=your_openai_key_here

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useSocket } from "./hooks/useSocket";
 import { ChatContainer } from "./components/chat/ChatContainer";
 import { Layout } from "./components/common/Layout";
 import { ArtifactWindow } from "./components/artifacts/ArtifactWindow";
+import { Sidebar } from "./components/sidebar/Sidebar";
 import { useEffect, useState } from "react";
 import "./App.css";
 
@@ -17,10 +18,12 @@ function App() {
     closeArtifact,
     toggleArtifact,
     sendMessage,
+    resetChat,
   } = useSocket();
   
   // State to track if there's a new artifact that hasn't been viewed
   const [hasNewArtifact, setHasNewArtifact] = useState(false);
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   
   // Reset the new artifact indicator when the artifact window is opened
   useEffect(() => {
@@ -40,7 +43,10 @@ function App() {
   const hasMessages = messages.length > 0;
 
   return (
-    <Layout>
+    <Layout
+      sidebar={<Sidebar isOpen={isSidebarOpen} onNewChat={resetChat} />}
+      onToggleSidebar={() => setIsSidebarOpen((prev) => !prev)}
+    >
       {isConnected && (
         <ChatContainer
           messages={messages}
@@ -63,10 +69,10 @@ function App() {
       )}
       
       {/* Artifact Window */}
-      <ArtifactWindow 
-        isOpen={isArtifactOpen} 
-        onClose={closeArtifact} 
-        artifact={artifact} 
+      <ArtifactWindow
+        isOpen={isArtifactOpen}
+        onClose={closeArtifact}
+        artifact={artifact}
       />
     </Layout>
   );

--- a/packages/frontend/src/components/common/Layout.css
+++ b/packages/frontend/src/components/common/Layout.css
@@ -16,6 +16,7 @@
   background-color: rgba(255, 255, 255, 0.05);
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
   text-align: center;
+  position: relative;
 }
 
 .app-header h1 {
@@ -30,6 +31,25 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+.app-body {
+  display: flex;
+  flex: 1;
+  width: 100%;
+  overflow: hidden;
+}
+
+.menu-button {
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: #ffffff;
+  font-size: 1.25rem;
+  cursor: pointer;
 }
 
 .app-footer {

--- a/packages/frontend/src/components/common/Layout.tsx
+++ b/packages/frontend/src/components/common/Layout.tsx
@@ -3,17 +3,27 @@ import './Layout.css';
 
 interface LayoutProps {
   children: ReactNode;
+  sidebar?: ReactNode;
+  onToggleSidebar?: () => void;
 }
 
-export const Layout: React.FC<LayoutProps> = ({ children }) => {
+export const Layout: React.FC<LayoutProps> = ({ children, sidebar, onToggleSidebar }) => {
   return (
     <div className="app">
       <header className="app-header">
+        {onToggleSidebar && (
+          <button className="menu-button" onClick={onToggleSidebar}>
+            &#9776;
+          </button>
+        )}
         <h1>AI Chat Assistant</h1>
       </header>
-      <main className="app-main">
-        {children}
-      </main>
+      <div className="app-body">
+        {sidebar}
+        <main className="app-main">
+          {children}
+        </main>
+      </div>
       <footer className="app-footer">
         <p>&copy; {new Date().getFullYear()} AI Chat Assistant</p>
       </footer>

--- a/packages/frontend/src/components/sidebar/Sidebar.css
+++ b/packages/frontend/src/components/sidebar/Sidebar.css
@@ -1,0 +1,38 @@
+.sidebar {
+  width: 250px;
+  background-color: #1e1e1e;
+  border-right: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.new-chat-button {
+  background-color: #646cff;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-bottom: 1rem;
+}
+
+.conversation-placeholder {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+  .sidebar {
+    position: fixed;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 1000;
+  }
+  .sidebar.open {
+    transform: translateX(0);
+  }
+}

--- a/packages/frontend/src/components/sidebar/Sidebar.tsx
+++ b/packages/frontend/src/components/sidebar/Sidebar.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import "./Sidebar.css";
+
+interface SidebarProps {
+  isOpen: boolean;
+  onNewChat: () => void;
+}
+
+export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onNewChat }) => {
+  return (
+    <aside className={`sidebar ${isOpen ? "open" : ""}`}>
+      <button className="new-chat-button" onClick={onNewChat}>
+        + New Chat
+      </button>
+      <div className="conversation-placeholder">
+        <p>No conversations yet</p>
+      </div>
+    </aside>
+  );
+};

--- a/packages/frontend/src/hooks/useSocket.ts
+++ b/packages/frontend/src/hooks/useSocket.ts
@@ -257,6 +257,13 @@ export const useSocket = (): UseSocketReturn => {
     setIsArtifactOpen(prev => !prev);
   };
 
+  const resetChat = () => {
+    setMessages([]);
+    setCurrentResponse("");
+    setArtifact(null);
+    setIsArtifactOpen(false);
+  };
+
   return {
     isConnected,
     connectionStatus,
@@ -269,6 +276,7 @@ export const useSocket = (): UseSocketReturn => {
     openArtifact,
     closeArtifact,
     toggleArtifact,
-    sendMessage
+    sendMessage,
+    resetChat
   };
 };


### PR DESCRIPTION
## Summary
- add collapsible sidebar component for ChatGPT-like UI
- update layout to include sidebar and menu button
- expose `resetChat` in `useSocket` hook
- integrate sidebar in `App`

## Testing
- `pnpm -r test` *(fails: vitest not found)*