### PR TITLE
Fix SSE chat by configurable model

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The backend requires an OpenAI API key. Copy the example file and add your key:
 ```bash
 cp packages/backend/.env.example packages/backend/.env
 # edit packages/backend/.env and set OPENAI_KEY=your_openai_key
+# optionally update OPENAI_MODEL if you have access to different models
 ```
 
 Restart the backend after updating the file.

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -1,1 +1,3 @@
 OPENAI_KEY=your_openai_key_here
+# Optional: specify the OpenAI model to use
+OPENAI_MODEL=gpt-3.5-turbo

--- a/packages/backend/src/controllers/stream.controller.ts
+++ b/packages/backend/src/controllers/stream.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { openai, getSystemPrompt, PromptType, extractArtifacts } from "@/services/openai";
+import { openai, getSystemPrompt, PromptType, extractArtifacts, defaultModel } from "@/services/openai";
 
 export async function streamChat(req: Request, res: Response) {
   const message = (req.query.message as string) || "";
@@ -18,7 +18,7 @@ export async function streamChat(req: Request, res: Response) {
 
   try {
     const stream = await openai.chat.completions.create({
-      model: "gpt-4o",
+      model: defaultModel,
       messages: [
         { role: "system", content: getSystemPrompt(promptType) },
         { role: "user", content: message },

--- a/packages/backend/src/services/openai.ts
+++ b/packages/backend/src/services/openai.ts
@@ -14,6 +14,9 @@ if (!apiKey) {
   process.exit(1);
 }
 
+// Determine which model to use, defaulting to gpt-3.5-turbo for broader access
+export const defaultModel = process.env.OPENAI_MODEL || "gpt-3.5-turbo";
+
 // Initialize OpenAI client
 export const openai = new OpenAI({
   apiKey: apiKey,
@@ -163,7 +166,7 @@ export async function generateResponse(
   try {
     // For non-streaming responses
     const response = await openai.chat.completions.create({
-      model: "gpt-4o",
+      model: defaultModel,
       messages: [
         { 
           role: "system", 


### PR DESCRIPTION
## Summary
- allow configuration of the OpenAI model in backend service
- default to `gpt-3.5-turbo` for wider availability
- expose `OPENAI_MODEL` in `.env.example`
- mention the optional model setting in README

## Testing
- `pnpm test` *(fails: lerna not found)*