### PR TITLE
Implement chat sessions and sidebar toggle

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -2,7 +2,8 @@ import { useSocket } from "./hooks/useSocket";
 import { ChatContainer } from "./components/chat/ChatContainer";
 import { Layout } from "./components/common/Layout";
 import { ArtifactWindow } from "./components/artifacts/ArtifactWindow";
-import { Sidebar } from "./components/sidebar/Sidebar";
+import { Sidebar, ChatSummary } from "./components/sidebar/Sidebar";
+import { Message } from "./types";
 import { useEffect, useState } from "react";
 import "./App.css";
 
@@ -18,9 +19,69 @@ function App() {
     closeArtifact,
     toggleArtifact,
     sendMessage,
+    setChatMessages,
     resetChat,
   } = useSocket();
-  
+
+  interface ChatSession {
+    id: string;
+    title: string;
+    messages: Message[];
+  }
+
+  const [chats, setChats] = useState<ChatSession[]>([]);
+  const [currentChatId, setCurrentChatId] = useState<string>("");
+
+  // Load chats from localStorage on mount
+  useEffect(() => {
+    const stored = localStorage.getItem("chatSessions");
+    if (stored) {
+      const parsed: ChatSession[] = JSON.parse(stored);
+      setChats(parsed);
+      if (parsed.length > 0) {
+        setCurrentChatId(parsed[0].id);
+        setChatMessages(parsed[0].messages);
+      }
+    } else {
+      handleNewChat();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Persist chats to localStorage whenever they change
+  useEffect(() => {
+    localStorage.setItem("chatSessions", JSON.stringify(chats));
+  }, [chats]);
+
+  // Update current chat messages when socket messages change
+  useEffect(() => {
+    if (!currentChatId) return;
+    setChats((prev) => {
+      const idx = prev.findIndex((c) => c.id === currentChatId);
+      if (idx === -1) return prev;
+      const updated = [...prev];
+      const existing = updated[idx];
+      const title = existing.title || messages.find((m) => m.sender === "user")?.content?.slice(0, 20) || "";
+      updated[idx] = { ...existing, messages, title };
+      return updated;
+    });
+  }, [messages, currentChatId]);
+
+  const handleNewChat = () => {
+    const newChat: ChatSession = { id: Date.now().toString(), title: "", messages: [] };
+    setChats((prev) => [newChat, ...prev]);
+    setCurrentChatId(newChat.id);
+    resetChat();
+  };
+
+  const handleSelectChat = (id: string) => {
+    const chat = chats.find((c) => c.id === id);
+    if (!chat) return;
+    setCurrentChatId(id);
+    resetChat();
+    setChatMessages(chat.messages);
+  };
+
   // State to track if there's a new artifact that hasn't been viewed
   const [hasNewArtifact, setHasNewArtifact] = useState(false);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
@@ -44,7 +105,15 @@ function App() {
 
   return (
     <Layout
-      sidebar={<Sidebar isOpen={isSidebarOpen} onNewChat={resetChat} />}
+      sidebar={
+        <Sidebar
+          isOpen={isSidebarOpen}
+          chats={chats.map(({ id, title }) => ({ id, title }))}
+          currentChatId={currentChatId}
+          onNewChat={handleNewChat}
+          onSelectChat={handleSelectChat}
+        />
+      }
       onToggleSidebar={() => setIsSidebarOpen((prev) => !prev)}
     >
       {isConnected && (

--- a/packages/frontend/src/components/sidebar/Sidebar.css
+++ b/packages/frontend/src/components/sidebar/Sidebar.css
@@ -5,6 +5,11 @@
   padding: 1rem;
   display: flex;
   flex-direction: column;
+  transition: transform 0.3s ease;
+}
+
+.sidebar.closed {
+  transform: translateX(-260px);
 }
 
 .new-chat-button {
@@ -22,15 +27,33 @@
   font-size: 0.9rem;
 }
 
+.chat-list {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.chat-item {
+  padding: 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-bottom: 0.5rem;
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.chat-item.active {
+  background-color: rgba(100, 108, 255, 0.4);
+}
+
 @media (max-width: 768px) {
   .sidebar {
     position: fixed;
     left: 0;
     top: 0;
     bottom: 0;
-    transform: translateX(-100%);
-    transition: transform 0.3s ease;
     z-index: 1000;
+  }
+  .sidebar.closed {
+    transform: translateX(-100%);
   }
   .sidebar.open {
     transform: translateX(0);

--- a/packages/frontend/src/components/sidebar/Sidebar.tsx
+++ b/packages/frontend/src/components/sidebar/Sidebar.tsx
@@ -1,20 +1,48 @@
 import React from "react";
 import "./Sidebar.css";
 
-interface SidebarProps {
-  isOpen: boolean;
-  onNewChat: () => void;
+export interface ChatSummary {
+  id: string;
+  title: string;
 }
 
-export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onNewChat }) => {
+interface SidebarProps {
+  isOpen: boolean;
+  chats: ChatSummary[];
+  currentChatId: string;
+  onNewChat: () => void;
+  onSelectChat: (id: string) => void;
+}
+
+export const Sidebar: React.FC<SidebarProps> = ({
+  isOpen,
+  chats,
+  currentChatId,
+  onNewChat,
+  onSelectChat,
+}) => {
   return (
-    <aside className={`sidebar ${isOpen ? "open" : ""}`}>
+    <aside className={`sidebar ${isOpen ? "open" : "closed"}`}>
       <button className="new-chat-button" onClick={onNewChat}>
         + New Chat
       </button>
-      <div className="conversation-placeholder">
-        <p>No conversations yet</p>
-      </div>
+      {chats.length === 0 ? (
+        <div className="conversation-placeholder">
+          <p>No conversations yet</p>
+        </div>
+      ) : (
+        <div className="chat-list">
+          {chats.map((chat, index) => (
+            <div
+              key={chat.id}
+              className={`chat-item ${chat.id === currentChatId ? "active" : ""}`}
+              onClick={() => onSelectChat(chat.id)}
+            >
+              {chat.title || `Chat ${index + 1}`}
+            </div>
+          ))}
+        </div>
+      )}
     </aside>
   );
 };

--- a/packages/frontend/src/hooks/useSocket.ts
+++ b/packages/frontend/src/hooks/useSocket.ts
@@ -21,6 +21,7 @@ interface UseChatReturn {
   closeArtifact: () => void;
   toggleArtifact: () => void;
   sendMessage: (message: string, promptType?: PromptType) => Promise<void>;
+  setChatMessages: (msgs: Message[]) => void;
   resetChat: () => void;
 }
 
@@ -181,6 +182,10 @@ export const useSocket = (): UseChatReturn => {
     setIsArtifactOpen((prev) => !prev);
   };
 
+  const setChatMessages = (msgs: Message[]) => {
+    setMessages(msgs);
+  };
+
   const resetChat = () => {
     setMessages([]);
     setCurrentResponse("");
@@ -201,6 +206,7 @@ export const useSocket = (): UseChatReturn => {
     closeArtifact,
     toggleArtifact,
     sendMessage,
+    setChatMessages,
     resetChat,
   };
 };


### PR DESCRIPTION
## Summary
- toggle sidebar visibility via hamburger menu
- manage chat sessions with localStorage persistence
- display chats in sidebar with ability to switch
- expose `setChatMessages` in `useSocket` hook

## Testing
- `npx lerna run test` *(fails: `lerna: not found`)*
- `npx vitest run` *(no tests found)*