### PR TITLE
Add playground route

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,81 +1,17 @@
-import { useSocket } from "./hooks/useSocket";
-import { ChatContainer } from "./components/chat/ChatContainer";
-import { Layout } from "./components/common/Layout";
-import { ArtifactWindow } from "./components/artifacts/ArtifactWindow";
-import { Sidebar } from "./components/sidebar/Sidebar";
-import { useEffect, useState } from "react";
-import "./App.css";
+import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import ChatPage from './pages/ChatPage';
+import Playground from './pages/Playground';
 
-function App() {
-  const {
-    isConnected,
-    isTyping,
-    currentResponse,
-    messages,
-    error,
-    artifact,
-    isArtifactOpen,
-    closeArtifact,
-    toggleArtifact,
-    sendMessage,
-    resetChat,
-  } = useSocket();
-  
-  // State to track if there's a new artifact that hasn't been viewed
-  const [hasNewArtifact, setHasNewArtifact] = useState(false);
-  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  
-  // Reset the new artifact indicator when the artifact window is opened
-  useEffect(() => {
-    if (isArtifactOpen) {
-      setHasNewArtifact(false);
-    }
-  }, [isArtifactOpen]);
-  
-  // Set the new artifact indicator when a new artifact is received
-  useEffect(() => {
-    if (artifact && !isArtifactOpen) {
-      setHasNewArtifact(true);
-    }
-  }, [artifact, isArtifactOpen]);
-  
-  // Always show the toggle button after the first message
-  const hasMessages = messages.length > 0;
-
+const App: React.FC = () => {
   return (
-    <Layout
-      sidebar={<Sidebar isOpen={isSidebarOpen} onNewChat={resetChat} />}
-      onToggleSidebar={() => setIsSidebarOpen((prev) => !prev)}
-    >
-      {isConnected && (
-        <ChatContainer
-          messages={messages}
-          currentResponse={currentResponse}
-          isTyping={isTyping}
-          error={error}
-          onSendMessage={sendMessage}
-        />
-      )}
-      
-      {/* Artifact Toggle Button - always show after first message */}
-      {hasMessages && (
-        <button 
-          className={`artifact-toggle-button ${hasNewArtifact ? 'has-new-artifact' : ''}`}
-          onClick={toggleArtifact}
-          title="Toggle Code Artifacts"
-        >
-          {isArtifactOpen ? '❌ Close Code' : hasNewArtifact ? '🔔 New Code!' : '📋 View Code'}
-        </button>
-      )}
-      
-      {/* Artifact Window */}
-      <ArtifactWindow
-        isOpen={isArtifactOpen}
-        onClose={closeArtifact}
-        artifact={artifact}
-      />
-    </Layout>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<ChatPage />} />
+        <Route path="/playground" element={<Playground />} />
+      </Routes>
+    </BrowserRouter>
   );
-}
+};
 
 export default App;

--- a/packages/frontend/src/components/common/Layout.css
+++ b/packages/frontend/src/components/common/Layout.css
@@ -81,3 +81,17 @@
   background-color: rgba(255, 0, 0, 0.1);
   border: 1px solid rgba(255, 0, 0, 0.3);
 }
+
+.app-nav {
+  margin-top: 0.5rem;
+}
+
+.app-nav a {
+  margin: 0 0.5rem;
+  color: inherit;
+  text-decoration: none;
+}
+
+.app-nav a:hover {
+  text-decoration: underline;
+}

--- a/packages/frontend/src/components/common/Layout.tsx
+++ b/packages/frontend/src/components/common/Layout.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
 import './Layout.css';
 
 interface LayoutProps {
@@ -17,6 +18,10 @@ export const Layout: React.FC<LayoutProps> = ({ children, sidebar, onToggleSideb
           </button>
         )}
         <h1>AI Chat Assistant</h1>
+        <nav className="app-nav">
+          <Link to="/">Home</Link>
+          <Link to="/playground">Playground</Link>
+        </nav>
       </header>
       <div className="app-body">
         {sidebar}

--- a/packages/frontend/src/pages/ChatPage.tsx
+++ b/packages/frontend/src/pages/ChatPage.tsx
@@ -1,0 +1,81 @@
+import { useSocket } from "../hooks/useSocket";
+import { ChatContainer } from "../components/chat/ChatContainer";
+import { Layout } from "../components/common/Layout";
+import { ArtifactWindow } from "../components/artifacts/ArtifactWindow";
+import { Sidebar } from "../components/sidebar/Sidebar";
+import { useEffect, useState } from "react";
+import "../App.css";
+
+function ChatPage() {
+  const {
+    isConnected,
+    isTyping,
+    currentResponse,
+    messages,
+    error,
+    artifact,
+    isArtifactOpen,
+    closeArtifact,
+    toggleArtifact,
+    sendMessage,
+    resetChat,
+  } = useSocket();
+  
+  // State to track if there's a new artifact that hasn't been viewed
+  const [hasNewArtifact, setHasNewArtifact] = useState(false);
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  
+  // Reset the new artifact indicator when the artifact window is opened
+  useEffect(() => {
+    if (isArtifactOpen) {
+      setHasNewArtifact(false);
+    }
+  }, [isArtifactOpen]);
+  
+  // Set the new artifact indicator when a new artifact is received
+  useEffect(() => {
+    if (artifact && !isArtifactOpen) {
+      setHasNewArtifact(true);
+    }
+  }, [artifact, isArtifactOpen]);
+  
+  // Always show the toggle button after the first message
+  const hasMessages = messages.length > 0;
+
+  return (
+    <Layout
+      sidebar={<Sidebar isOpen={isSidebarOpen} onNewChat={resetChat} />}
+      onToggleSidebar={() => setIsSidebarOpen((prev) => !prev)}
+    >
+      {isConnected && (
+        <ChatContainer
+          messages={messages}
+          currentResponse={currentResponse}
+          isTyping={isTyping}
+          error={error}
+          onSendMessage={sendMessage}
+        />
+      )}
+      
+      {/* Artifact Toggle Button - always show after first message */}
+      {hasMessages && (
+        <button 
+          className={`artifact-toggle-button ${hasNewArtifact ? 'has-new-artifact' : ''}`}
+          onClick={toggleArtifact}
+          title="Toggle Code Artifacts"
+        >
+          {isArtifactOpen ? '❌ Close Code' : hasNewArtifact ? '🔔 New Code!' : '📋 View Code'}
+        </button>
+      )}
+      
+      {/* Artifact Window */}
+      <ArtifactWindow
+        isOpen={isArtifactOpen}
+        onClose={closeArtifact}
+        artifact={artifact}
+      />
+    </Layout>
+  );
+}
+
+export default ChatPage;

--- a/packages/frontend/src/pages/Playground.tsx
+++ b/packages/frontend/src/pages/Playground.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Layout } from '../components/common/Layout';
+
+const Playground: React.FC = () => {
+  return (
+    <Layout>
+      <div style={{ padding: '1rem' }}>
+        <h2>Playground</h2>
+        <p>This area can be used for testing components.</p>
+      </div>
+    </Layout>
+  );
+};
+
+export default Playground;


### PR DESCRIPTION
## Summary
- add react-router setup with new /playground path
- move chat logic into a dedicated `ChatPage`
- add simple `Playground` page
- include navigation links in `Layout`

## Testing
- `pnpm -r test` *(fails: vitest not found)*