### PR TITLE
Add settings dropdown with routes and preferences

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -2,15 +2,24 @@ import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import ChatPage from './pages/ChatPage';
 import Playground from './pages/Playground';
+import SettingsPage from './pages/SettingsPage';
+import ThemePage from './pages/ThemePage';
+import PreferencesPage from './pages/PreferencesPage';
+import { SettingsProvider } from './context/SettingsContext';
 
 const App: React.FC = () => {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<ChatPage />} />
-        <Route path="/playground" element={<Playground />} />
-      </Routes>
-    </BrowserRouter>
+    <SettingsProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<ChatPage />} />
+          <Route path="/playground" element={<Playground />} />
+          <Route path="/settings" element={<SettingsPage />} />
+          <Route path="/theme" element={<ThemePage />} />
+          <Route path="/preferences" element={<PreferencesPage />} />
+        </Routes>
+      </BrowserRouter>
+    </SettingsProvider>
   );
 };
 

--- a/packages/frontend/src/components/common/Layout.css
+++ b/packages/frontend/src/components/common/Layout.css
@@ -95,3 +95,41 @@
 .app-nav a:hover {
   text-decoration: underline;
 }
+
+.settings-button {
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: #ffffff;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+
+.settings-menu {
+  position: absolute;
+  right: 1rem;
+  top: calc(100% + 0.5rem);
+  background-color: #1e1e1e;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  list-style: none;
+  padding: 0.5rem 0;
+  margin: 0;
+  z-index: 1000;
+}
+
+.settings-menu li {
+  padding: 0.5rem 1rem;
+}
+
+.settings-menu li:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.settings-menu li a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/packages/frontend/src/components/common/Layout.tsx
+++ b/packages/frontend/src/components/common/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { Link } from 'react-router-dom';
 import './Layout.css';
 
@@ -9,6 +9,8 @@ interface LayoutProps {
 }
 
 export const Layout: React.FC<LayoutProps> = ({ children, sidebar, onToggleSidebar }) => {
+  const [showMenu, setShowMenu] = useState(false);
+
   return (
     <div className="app">
       <header className="app-header">
@@ -22,6 +24,22 @@ export const Layout: React.FC<LayoutProps> = ({ children, sidebar, onToggleSideb
           <Link to="/">Home</Link>
           <Link to="/playground">Playground</Link>
         </nav>
+        <button className="settings-button" onClick={() => setShowMenu((p) => !p)}>
+          ⚙
+        </button>
+        {showMenu && (
+          <ul className="settings-menu" onMouseLeave={() => setShowMenu(false)}>
+            <li>
+              <Link to="/settings" onClick={() => setShowMenu(false)}>Settings</Link>
+            </li>
+            <li>
+              <Link to="/theme" onClick={() => setShowMenu(false)}>Theme</Link>
+            </li>
+            <li>
+              <Link to="/preferences" onClick={() => setShowMenu(false)}>Preferences</Link>
+            </li>
+          </ul>
+        )}
       </header>
       <div className="app-body">
         {sidebar}

--- a/packages/frontend/src/context/SettingsContext.tsx
+++ b/packages/frontend/src/context/SettingsContext.tsx
@@ -1,0 +1,38 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+interface SettingsContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+  defaultSidebarOpen: boolean;
+  setDefaultSidebarOpen: (value: boolean) => void;
+}
+
+const SettingsContext = createContext<SettingsContextType>({
+  theme: 'dark',
+  toggleTheme: () => {},
+  defaultSidebarOpen: false,
+  setDefaultSidebarOpen: () => {},
+});
+
+export const useSettings = () => useContext(SettingsContext);
+
+interface ProviderProps { children: ReactNode }
+
+export const SettingsProvider: React.FC<ProviderProps> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>('dark');
+  const [defaultSidebarOpen, setDefaultSidebarOpen] = useState(false);
+
+  useEffect(() => {
+    document.body.style.backgroundColor = theme === 'light' ? '#ffffff' : '#121212';
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+
+  return (
+    <SettingsContext.Provider value={{ theme, toggleTheme, defaultSidebarOpen, setDefaultSidebarOpen }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};

--- a/packages/frontend/src/pages/ChatPage.tsx
+++ b/packages/frontend/src/pages/ChatPage.tsx
@@ -4,6 +4,7 @@ import { Layout } from "../components/common/Layout";
 import { ArtifactWindow } from "../components/artifacts/ArtifactWindow";
 import { Sidebar } from "../components/sidebar/Sidebar";
 import { useEffect, useState } from "react";
+import { useSettings } from "../context/SettingsContext";
 import "../App.css";
 
 function ChatPage() {
@@ -20,10 +21,16 @@ function ChatPage() {
     sendMessage,
     resetChat,
   } = useSocket();
+
+  const { defaultSidebarOpen } = useSettings();
   
   // State to track if there's a new artifact that hasn't been viewed
   const [hasNewArtifact, setHasNewArtifact] = useState(false);
-  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [isSidebarOpen, setIsSidebarOpen] = useState(defaultSidebarOpen);
+
+  useEffect(() => {
+    setIsSidebarOpen(defaultSidebarOpen);
+  }, [defaultSidebarOpen]);
   
   // Reset the new artifact indicator when the artifact window is opened
   useEffect(() => {

--- a/packages/frontend/src/pages/PreferencesPage.tsx
+++ b/packages/frontend/src/pages/PreferencesPage.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Layout } from '../components/common/Layout';
+import { useSettings } from '../context/SettingsContext';
+
+const PreferencesPage: React.FC = () => {
+  const { defaultSidebarOpen, setDefaultSidebarOpen } = useSettings();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setDefaultSidebarOpen(e.target.checked);
+  };
+
+  return (
+    <Layout>
+      <div style={{ padding: '1rem' }}>
+        <h2>Preferences</h2>
+        <div style={{ marginBottom: '1rem' }}>
+          <label>
+            Language:
+            <select style={{ marginLeft: '0.5rem' }}>
+              <option value="en">English</option>
+              <option value="es">Spanish</option>
+              <option value="fr">French</option>
+            </select>
+          </label>
+        </div>
+        <div>
+          <label>
+            <input type="checkbox" checked={defaultSidebarOpen} onChange={handleChange} />
+            {' '}Open sidebar by default
+          </label>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default PreferencesPage;

--- a/packages/frontend/src/pages/SettingsPage.tsx
+++ b/packages/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Layout } from '../components/common/Layout';
+
+const SettingsPage: React.FC = () => {
+  return (
+    <Layout>
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+        <h2>This page is under development</h2>
+      </div>
+    </Layout>
+  );
+};
+
+export default SettingsPage;

--- a/packages/frontend/src/pages/ThemePage.tsx
+++ b/packages/frontend/src/pages/ThemePage.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Layout } from '../components/common/Layout';
+import { useSettings } from '../context/SettingsContext';
+
+const ThemePage: React.FC = () => {
+  const { theme, toggleTheme } = useSettings();
+  return (
+    <Layout>
+      <div style={{ padding: '1rem' }}>
+        <h2>Theme Settings</h2>
+        <p>Current theme: {theme}</p>
+        <button onClick={toggleTheme}>Toggle Theme</button>
+      </div>
+    </Layout>
+  );
+};
+
+export default ThemePage;


### PR DESCRIPTION
## Summary
- add settings button with dropdown menu
- implement SettingsContext for theme and sidebar preferences
- create pages for Settings, Theme, and Preferences
- hook up routes and provider
- update ChatPage to respect sidebar default

## Testing
- `npx lerna run test` *(fails: EHOSTUNREACH)*